### PR TITLE
修复 SakanaWidget 插件层级问题

### DIFF
--- a/src/main/java/run/halo/sakanawidget/SakanaWidget.java
+++ b/src/main/java/run/halo/sakanawidget/SakanaWidget.java
@@ -24,18 +24,23 @@ public class SakanaWidget implements TemplateHeadProcessor {
              <link rel="stylesheet" href="%1$s/sakana.min.css"/>
              <link rel="stylesheet" href="%1$s/css/sakana.css"/>
 
-             <div id="sakana-widget" class="sakana-float" style="
-                 position: fixed;
-                 right: 40px;
-                 bottom: 45px;
-                 z-index: 10;
-             "></div>
+             <script defer src="%1$s/sakana.min.js?v=%2$s"></script>
+             <script>
+                 // 动态追加到 body 末尾
+                 const widgetDiv = document.createElement('div');
+                 widgetDiv.id = 'sakana-widget';
+                 widgetDiv.className = 'sakana-float';
+                 widgetDiv.style.position = 'fixed';
+                 widgetDiv.style.right = '40px';
+                 widgetDiv.style.bottom = '45px';
+                 widgetDiv.style.zIndex = '9999';
+                 document.body.appendChild(widgetDiv);
 
-                  <script src="%1$s/sakana.min.js?v=%2$s"></script>
-                    <script>
-                         new SakanaWidget().mount('#sakana-widget');
-                  </script>
-
+                 // 确保脚本加载后初始化
+                 window.addEventListener('load', () => {
+                     new SakanaWidget().mount('#sakana-widget');
+                 });
+             </script>
              """.formatted(STATIC_PATH, version);
 
         model.add(modelFactory.createText(injectHtml));


### PR DESCRIPTION
此 PR 修复 SakanaWidget 插件未始终显示在页面最顶层的问题，主要改动如下：

1. 将 `z-index` 提升至 `9999`，确保小部件位于顶层。
2. 使用 JavaScript 动态追加 `#sakana-widget` 到 `<body>` 末尾，优化渲染位置。
3. 添加 `defer` 和 `window.addEventListener('load', ...)`，确保脚本加载顺序正确。

**测试**:
由于我电脑缺失一些必要的环境和软件，无法打败jar进行测试，请测试通过后再发布。

**影响**:
- 仅优化层级和加载逻辑

请审阅！