### PR TITLE
优化静态资源缓存策略

### DIFF
--- a/src/main/java/run/halo/sakanawidget/SakanaWidget.java
+++ b/src/main/java/run/halo/sakanawidget/SakanaWidget.java
@@ -16,12 +16,12 @@ public class SakanaWidget implements TemplateHeadProcessor {
 
     private final PluginDescriptor pluginDescriptor;
 
-    公共 SakanaWidget(PluginDescriptor pluginDescriptor) {
+    public SakanaWidget(PluginDescriptor pluginDescriptor) {
         this.pluginDescriptor = pluginDescriptor;
     }
 
     @Override
-    公共 Mono<Void> process(ITemplateContext context, IModel model,
+    public Mono<Void> process(ITemplateContext context, IModel model,
         IElementModelStructureHandler structureHandler) {
         final IModelFactory modelFactory = context.getModelFactory();
 

--- a/src/main/java/run/halo/sakanawidget/SakanaWidget.java
+++ b/src/main/java/run/halo/sakanawidget/SakanaWidget.java
@@ -6,6 +6,7 @@ import org.thymeleaf.model.IModel;
 import org.thymeleaf.model.IModelFactory;
 import org.thymeleaf.processor.element.IElementModelStructureHandler;
 import reactor.core.publisher.Mono;
+import run.halo.app.plugin.PluginDescriptor;
 import run.halo.app.theme.dialect.TemplateHeadProcessor;
 
 @Component
@@ -13,12 +14,18 @@ public class SakanaWidget implements TemplateHeadProcessor {
 
     private static final String STATIC_PATH = "/plugins/SakanaWidget/assets/res";
 
+    private final PluginDescriptor pluginDescriptor;
+
+    公共 SakanaWidget(PluginDescriptor pluginDescriptor) {
+        this.pluginDescriptor = pluginDescriptor;
+    }
+
     @Override
-    public Mono<Void> process(ITemplateContext context, IModel model,
+    公共 Mono<Void> process(ITemplateContext context, IModel model,
         IElementModelStructureHandler structureHandler) {
         final IModelFactory modelFactory = context.getModelFactory();
 
-        String version = String.valueOf(System.currentTimeMillis());
+        String version = pluginDescriptor.getVersion().toString();
 
         String injectHtml = """
              <link rel="stylesheet" href="%1$s/sakana.min.css"/>


### PR DESCRIPTION
目前的代码使用时间戳`System.currentTimeMillis()`作为静态资源版本号，这会导致浏览器每次都重新加载资源，无法利用缓存，影响性能。

此次修改应该能利用缓存，另外合并前建议打包测试